### PR TITLE
Update dependencies to newer versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "sinon": "^1.10.3"
   },
   "dependencies": {
-    "bonescript": "^0.2.4",
-    "i2c-bus": "^0.11.2"
+    "bonescript": "^0.5.0",
+    "i2c-bus": "^1.1.2"
   }
 }


### PR DESCRIPTION
Updating dependencies to bonescript@0.5.0 and i2c-bus@1.1.2 allows beaglebone-io to build successfully on BeagleBoard.org Debian Image 2016-05-13.  Fix for issue #25
