### PR TITLE
update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "sinon": "^2.1.0"
   },
   "dependencies": {
-    "linux-io": "^0.5.7",
-    "glob": "^7.1.1"
+    "linux-io": "^0.6.2",
+    "glob": "^7.1.2"
   }
 }


### PR DESCRIPTION
This PR updates the dependencies. In particular, it updates the linux-io dependency to fix a bug in digitalWrite. If the mode for a pin is not set to OUTPUT when digitalWrite is called, the mode for the pin should be automatically set to OUTPUT. This bug was fixed with linux-io@0.6.2