### PR TITLE
Add support for Debian Stretch and the Linux 4.9 kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
 # BeagleBone-IO
 BeagleBone Black IO Plugin for [Johnny-Five](http://johnny-five.io).
 
-BeagleBone-IO supports Node.js v0.10, v0.12, v4, v5, v6, v7 and 8.
+BeagleBone-IO supports Node.js version 0.10, 0.12, 4, 5, 6, 7 and 8.
 
 ## News & Updates
+
+### August-2017: Debian Stretch support
+
+BeagleBone-IO v2.2.0 adds support for Debian Stretch and the Linux 4.9 kernel.
+This is not a breaking change and v2.2.0 continues to support Debian Jessie and
+the Linux 4.4 kernel.
 
 ### April-2017: Major changes for BeagleBone-IO v2.0.0
 

--- a/lib/analog-input.js
+++ b/lib/analog-input.js
@@ -27,5 +27,9 @@ AnalogInput.prototype.rawValue = function () {
   return parseInt(this._rawValueBuffer.toString('utf8', 0, len - 1), 10);
 };
 
+AnalogInput.isEnabled = function () {
+  return fs.existsSync(ADC_PATH);
+};
+
 module.exports = AnalogInput;
 

--- a/lib/beaglebone.js
+++ b/lib/beaglebone.js
@@ -22,7 +22,10 @@ function BeagleBone() {
     vref: 3.3
   });
 
-  slots.add('BB-ADC');
+  // Analog inputs are enabled by default on Debian Stretch but not on Jessie
+  if (!AnalogInput.isEnabled()) {
+    slots.add('BB-ADC');
+  }
 
   setImmediate(function () {
     this.emit('connect');

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "sinon": "^2.1.0"
   },
   "dependencies": {
-    "linux-io": "^0.6.2",
+    "linux-io": "^0.8.0",
     "glob": "^7.1.2"
   }
 }


### PR DESCRIPTION
Fixes #38 (Applications don't work on Debian Stretch)

Note that this PR also adds the below text to the News & Updates section of the readme. If the PR isn't merged in August-2017 or if the version number is bumped to something other that v2.2.0 the text will need to be changed accordingly.

### August-2017: Debian Stretch support

BeagleBone-IO v2.2.0 adds support for Debian Stretch and the Linux 4.9 kernel.
This is not a breaking change and v2.2.0 continues to support Debian Jessie and
the Linux 4.4 kernel.
