### PR TITLE
Add support for the PocketBeagle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
 # BeagleBone-IO
-BeagleBone Black IO Plugin for [Johnny-Five](http://johnny-five.io).
+[Johnny-Five](http://johnny-five.io) IO Plugin for the BeagleBone Black and
+PocketBeagle.
 
-BeagleBone-IO supports Node.js version 0.10, 0.12, 4, 5, 6, 7 and 8.
+BeagleBone-IO supports Node.js version 0.10, 0.12, 4, 5, 6, 7, 8 and 9.
 
 ## News & Updates
+
+### November-2017: PocketBeagle support
+
+BeagleBone-IO v2.3.0 adds support for the
+[PocketBeagle](https://beagleboard.org/pocket).
 
 ### August-2017: Debian Stretch support
 
@@ -34,11 +40,12 @@ System is [Debian](http://beagleboard.org/latest-images).
 
 #### Standalone Usage of BeagleBone-IO
 
-Turn built-in user LED 3 on and log the value of analog input A0 to the
-console each time it changes. The BeagleBone Black has row of four built-in
-blue LEDs mounted on the board itself. User LED 3 is the LED closest to
-Ethernet port. It's possible to try this program without connecting any
-hardware to the BeagleBone Black.
+Both the BeagleBone Black and the PocketBeagle have four built-in blue user
+LEDs mounted on the board itself. The IDs for these LEDs are USR0, USR1, USR2
+and USR3. Both boards also have an analog input with the ID A0. The program
+below turns on LED USR3 and logs the value of analog input A0 to the console
+each time it changes. It's possible to try this program without connecting any
+additional hardware to the board.
 
 ``` js
 var BeagleBone = require('beaglebone-io');
@@ -57,18 +64,20 @@ board.on('ready', function () {
 
 #### Using BeagleBone-IO with Johnny-Five
 
-To use BeagleBone-IO with Johnny-Five the johnny-five package needs to be
-installed.
+To use BeagleBone-IO with Johnny-Five the beaglebone-io and the johnny-five
+packages need to be installed.
 
 ```
-npm install johnny-five
+npm install johnny-five beaglebone-io
 ```
 
-Blink the default LED with Johnny-Five. Built-in User LED 3 is the default
-LED. It's possible to try this program without connecting any hardware to
-the BeagleBone Black. Note how the `Led` constructor is called without any
-arguments. If no arguments are passed to the `Led` constructor Johnny-Five
-assumes that the default LED should be used.
+The next example blinks the default LED with Johnny-Five. The built-in LED
+with ID USR3 is the default LED on both the BeagleBone Black and the
+PocketBeagle. It's possible to try this program on either a BeagleBone Black
+or PocketBeagle without connecting any additional hardware to board. Note how
+the `Led` constructor is called without any arguments. If no arguments are
+passed to the `Led` constructor Johnny-Five assumes that the default LED
+should be used.
 
 ``` js
 var five = require('johnny-five');
@@ -84,7 +93,9 @@ board.on('ready', function () {
 });
 ```
 
-Pulse an LED connected to P8_13 with Johnny-Five.
+Pulse an LED connected to P8_13 on a BeagleBone Black with Johnny-Five. Note
+that pin ID P8_13 is specific to the BeagleBone Black so this program can't be
+run on a PocketBeagle.
 
 ``` js
 var five = require('johnny-five');
@@ -100,7 +111,25 @@ board.on('ready', function() {
 });
 ```
 
-## Supported Pins
+Pulse an LED connected to P2_1 on a PocketBeagle with Johnny-Five. Note that
+pin ID P2_1 is specific to the PocketBeagle so this program can't be run on a
+BeagleBone Black.
+
+``` js
+var five = require('johnny-five');
+var BeagleBone = require('beaglebone-io');
+
+var board = new five.Board({
+  io: new BeagleBone()
+});
+
+board.on('ready', function() {
+  var led = new five.Led('P2_1');
+  led.pulse(1000);
+});
+```
+
+## Supported Pins on the BeagleBone Black
 
 | Pin ID | Supported Modes | Comments |
 |:----|:-----|:----|
@@ -118,6 +147,7 @@ board.on('ready', function() {
 | P8_18 or GPIO65 | INPUT, OUTPUT | |
 | P8_19 or GPIO22 | INPUT, OUTPUT, SERVO, PWM | |
 | P8_26 or GPIO61 | INPUT, OUTPUT | |
+| | |
 | P9_11 or GPIO30 | INPUT, OUTPUT | |
 | P9_12 or GPIO60 | INPUT, OUTPUT | |
 | P9_13 or GPIO31 | INPUT, OUTPUT | |
@@ -144,6 +174,7 @@ board.on('ready', function() {
 | P9_40 or A1 | ANALOG | Don't input more than 1.8V |
 | P9_41 or GPIO20 | INPUT, OUTPUT | |
 | P9_42 or GPIO7 | INPUT, OUTPUT, SERVO, PWM | |
+| | |
 | USR0 | OUTPUT | Built-in user LED 0 |
 | USR1 | OUTPUT | Built-in user LED 1 |
 | USR2 | OUTPUT | Built-in user LED 2 |
@@ -163,6 +194,75 @@ The following image of the expansion headers shows the GPIO numbers for the
 header pins.
 
 <img src="http://beagleboard.org/static/images/cape-headers-digital.png">
+
+## Supported Pins on the PocketBeagle
+
+| Pin ID | Supported Modes | Comments |
+|:----|:-----|:----|
+| P1_2 or GPIO87 | INPUT, OUTPUT | |
+| P1_4 or GPIO89 | INPUT, OUTPUT | |
+| P1_6 or GPIO5 | INPUT, OUTPUT | |
+| P1_8 or GPIO2 | INPUT, OUTPUT | |
+| P1_10 or GPIO3 | INPUT, OUTPUT | |
+| P1_12 or GPIO4 | INPUT, OUTPUT | |
+| P1_19 or A0 | ANALOG | Don't input more than 1.8V |
+| P1_20 or GPIO20 | INPUT, OUTPUT | |
+| P1_21 or A1 | ANALOG | Don't input more than 1.8V |
+| P1_23 or A2 | ANALOG | Don't input more than 1.8V |
+| P1_25 or A3 | ANALOG | Don't input more than 1.8V |
+| P1_26 or GPIO12 | INPUT, OUTPUT | Optionally for I2C data |
+| P1_27 or A4 | ANALOG | Don't input more than 1.8V |
+| P1_28 or GPIO13 | INPUT, OUTPUT | Optionally for I2C clock |
+| P1_29 or GPIO117 | INPUT, OUTPUT | |
+| P1_30 or GPIO43 | INPUT, OUTPUT | |
+| P1_31 or GPIO114 | INPUT, OUTPUT | |
+| P1_32 or GPIO42 | INPUT, OUTPUT | |
+| P1_33 or GPIO111 | INPUT, OUTPUT, SERVO, PWM | |
+| P1_34 or GPIO26 | INPUT, OUTPUT | |
+| P1_35 or GPIO88 | INPUT, OUTPUT | |
+| P1_36 or GPIO110 | INPUT, OUTPUT, SERVO, PWM | |
+| | |
+| P2_1 or GPIO50 | INPUT, OUTPUT, SERVO, PWM | |
+| P2_2 or GPIO59 | INPUT, OUTPUT | |
+| P2_3 or GPIO23 | INPUT, OUTPUT, SERVO, PWM | |
+| P2_4 or GPIO58 | INPUT, OUTPUT | |
+| P2_5 or GPIO30 | INPUT, OUTPUT | |
+| P2_6 or GPIO57 | INPUT, OUTPUT | |
+| P2_7 or GPIO31 | INPUT, OUTPUT | |
+| P2_8 or GPIO60 | INPUT, OUTPUT | |
+| P2_9 or GPIO15 | INPUT, OUTPUT | |
+| P2_10 or GPIO52 | INPUT, OUTPUT | |
+| P2_11 or GPIO14 | INPUT, OUTPUT | |
+| P2_17 or GPIO65 | INPUT, OUTPUT | |
+| P2_18 or GPIO47 | INPUT, OUTPUT | |
+| P2_19 or GPIO27 | INPUT, OUTPUT | |
+| P2_20 or GPIO64 | INPUT, OUTPUT | |
+| P2_22 or GPIO46 | INPUT, OUTPUT | |
+| P2_24 or GPIO44 | INPUT, OUTPUT | |
+| P2_25 or GPIO41 | INPUT, OUTPUT | |
+| P2_27 or GPIO40 | INPUT, OUTPUT | |
+| P2_28 or GPIO116 | INPUT, OUTPUT | |
+| P2_29 or GPIO7 | INPUT, OUTPUT | |
+| P2_30 or GPIO113 | INPUT, OUTPUT | |
+| P2_31 or GPIO19 | INPUT, OUTPUT | |
+| P2_32 or GPIO112 | INPUT, OUTPUT | |
+| P2_33 or GPIO45 | INPUT, OUTPUT | |
+| P2_34 or GPIO115 | INPUT, OUTPUT | |
+| P2_35 or GPIO86 | INPUT, OUTPUT | |
+| | |
+| USR0 | OUTPUT | Built-in user LED 0 |
+| USR1 | OUTPUT | Built-in user LED 1 |
+| USR2 | OUTPUT | Built-in user LED 2 |
+| USR3 | OUTPUT | Built-in user LED 3 / Default LED |
+
+Below is an images of the PocketBeagle expansion headers from the
+[PocketBeagle repository on GitHub](https://github.com/beagleboard/pocketbeagle).
+
+Note that although the image indicates that GPIO109 is available on P1_3 this
+isn't the case as P1_3 is reserved for USB1-V_EN. In addition, the analog mode
+capabilities of P1_2, P2_35 and P2_36 are not supported by BeagleBone-IO.
+
+<img src="https://raw.githubusercontent.com/beagleboard/pocketbeagle/master/docs/PocketBeagle_pinout.png">
 
 ## Migrating from BeagleBone-IO v1 to v2
 

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ header pins.
 | USR2 | OUTPUT | Built-in user LED 2 |
 | USR3 | OUTPUT | Built-in user LED 3 / Default LED |
 
-Below is an images of the PocketBeagle expansion headers from the
+Below is an image of the PocketBeagle expansion headers from the
 [PocketBeagle repository on GitHub](https://github.com/beagleboard/pocketbeagle).
 
 Note that although the image indicates that GPIO109 is available on P1_3 this

--- a/lib/beagle-bone-black-pins.js
+++ b/lib/beagle-bone-black-pins.js
@@ -82,8 +82,8 @@ module.exports = [
   { ids: ['P9_42', 'GPIO7'], gpioNo: 7, modes: [0, 1, 3, 4], custom: { id: 'P9_42', pwm: pwmPins.p9_42 } },
   /* P9_43 - P9_46: DGND */
 
-  { ids: ['USR0'], ledPath: '/sys/class/leds/beaglebone:green:usr2', modes: [1] },
-  { ids: ['USR1'], ledPath: '/sys/class/leds/beaglebone:green:usr3', modes: [1] },
+  { ids: ['USR0'], ledPath: '/sys/class/leds/beaglebone:green:usr0', modes: [1] },
+  { ids: ['USR1'], ledPath: '/sys/class/leds/beaglebone:green:usr1', modes: [1] },
   { ids: ['USR2'], ledPath: '/sys/class/leds/beaglebone:green:usr2', modes: [1] },
   { ids: ['USR3'], ledPath: '/sys/class/leds/beaglebone:green:usr3', modes: [1] }
 ];

--- a/lib/beaglebone.js
+++ b/lib/beaglebone.js
@@ -2,7 +2,7 @@
 
 var LinuxIO = require('linux-io'),
   util = require('util'),
-  pins = require('./pins'),
+  boardInfo = require('./board-info'),
   AnalogInput = require('./analog-input'),
   PwmOutput = require('./pwm-output'),
   slots = require('./slots'),
@@ -13,6 +13,8 @@ var PWM_PERIOD = 1e9 / 2000, // 2000Hz
   PULSES_PER_MICROSEC = 1e9 / 1e6;
 
 function BeagleBone() {
+  var pins = boardInfo.pins();
+
   LinuxIO.call(this, {
     name: 'BeagleBone-IO',
     pins: pins,

--- a/lib/board-info.js
+++ b/lib/board-info.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var fs = require('fs'),
+  beagleBoneBlackPins = require('./beagle-bone-black-pins'),
+  pocketBeaglePins = require('./pocket-beagle-pins');
+
+var MODEL_FILE_PATH = '/proc/device-tree/model',
+  FS_OPTIONS = {encoding: 'utf8'};
+
+module.exports.pins = function () {
+  var model;
+
+  try {
+    model = fs.readFileSync(MODEL_FILE_PATH, FS_OPTIONS);
+  } catch (ignore) {
+  }
+
+  if (model === 'TI AM335x BeagleBone Black\u0000') {
+    return beagleBoneBlackPins;
+  } else if (model === 'TI AM335x PocketBeagle\u0000') {
+    return pocketBeaglePins;
+  } else {
+    return beagleBoneBlackPins;
+  }
+};
+

--- a/lib/pocket-beagle-pins.js
+++ b/lib/pocket-beagle-pins.js
@@ -1,0 +1,110 @@
+'use strict';
+
+/*
+ * erhpwm0 channel 1 can be configured for output on P1_10 and/or P1_33.
+ * If both P1_10 and P1_33 are defined to support PWM, Johnny-Five will
+ * assume that it has two independent PWM channels but in reality there is
+ * only one channel. To avoid issues here P1_33 is defined to support PWM
+ * but P1_10 is not. The same applies to P1_8 and/or P1_36.
+ */
+
+var pwmSubSystems = {
+  subSystem0: { addr: 0x48300000 },
+  subSystem1: { addr: 0x48302000 },
+  subSystem2: { addr: 0x48304000 }
+};
+
+var pwmModules = {
+  ehrpwm0: { subSystem: pwmSubSystems.subSystem0, addr: 0x48300200, suffix: 'pwm' },
+  ehrpwm1: { subSystem: pwmSubSystems.subSystem1, addr: 0x48302200, suffix: 'pwm' },
+  ehrpwm2: { subSystem: pwmSubSystems.subSystem2, addr: 0x48304200, suffix: 'pwm' }
+};
+
+var pwmPins = {
+  p1_33: { module: pwmModules.ehrpwm0, channel: 1 },
+  p1_36: { module: pwmModules.ehrpwm0, channel: 0 },
+  p2_1: { module: pwmModules.ehrpwm1, channel: 0 },
+  p2_3: { module: pwmModules.ehrpwm2, channel: 1 }
+};
+
+module.exports = [
+  /* P1_1: VIN */
+  { ids: ['P1_2', 'GPIO87'], gpioNo: 87, modes: [0, 1], custom: { id: 'P1_02' } },
+  /* P1_3: USB1-V_EN */
+  { ids: ['P1_4', 'GPIO89'], gpioNo: 89, modes: [0, 1], custom: { id: 'P1_04' } },
+  /* P1_5: USB1-VBUS */
+  { ids: ['P1_6', 'GPIO5'], gpioNo: 5, modes: [0, 1], custom: { id: 'P1_06' } },
+  /* P1_7: USB1-VIN */
+  { ids: ['P1_8', 'GPIO2'], gpioNo: 2, modes: [0, 1], custom: { id: 'P1_08' } },
+  /* P1_9: USB1-DN */
+  { ids: ['P1_10', 'GPIO3'], gpioNo: 3, modes: [0, 1], custom: { id: 'P1_10' } },
+  /* P1_11: USB1-DP */
+  { ids: ['P1_12', 'GPIO4'], gpioNo: 4, modes: [0, 1], custom: { id: 'P1_12' } },
+  /* P1_13: USB1-ID */
+  /* P1_14: 3.3V */
+  /* P1_15: USB1-GND*/
+  /* P1_16: GND */
+  /* P1_17: AIN-VREF- */
+  /* P1_18: AIN-VREF+ */
+  { ids: ['P1_19', 'A0'], analogChannel: 0, modes: [2], custom: { id: 'P1_19' } },
+  { ids: ['P1_20', 'GPIO20'], gpioNo: 20, modes: [0, 1], custom: { id: 'P1_20' } },
+  { ids: ['P1_21', 'A1'], analogChannel: 1, modes: [2], custom: { id: 'P1_21' } },
+  /* P1_22: GND */
+  { ids: ['P1_23', 'A2'], analogChannel: 2, modes: [2], custom: { id: 'P1_23' } },
+  /* P1_24: VOUT-5V */
+  { ids: ['P1_25', 'A3'], analogChannel: 3, modes: [2], custom: { id: 'P1_25' } },
+  { ids: ['P1_26', 'GPIO12'], gpioNo: 12, modes: [0, 1], custom: { id: 'P1_26' } },
+  { ids: ['P1_27', 'A4'], analogChannel: 4, modes: [2], custom: { id: 'P1_27' } },
+  { ids: ['P1_28', 'GPIO13'], gpioNo: 13, modes: [0, 1], custom: { id: 'P1_28' } },
+  { ids: ['P1_29', 'GPIO117'], gpioNo: 117, modes: [0, 1], custom: { id: 'P1_29' } },
+  { ids: ['P1_30', 'GPIO43'], gpioNo: 43, modes: [0, 1], custom: { id: 'P1_30' } },
+  { ids: ['P1_31', 'GPIO114'], gpioNo: 114, modes: [0, 1], custom: { id: 'P1_31' } },
+  { ids: ['P1_32', 'GPIO42'], gpioNo: 42, modes: [0, 1], custom: { id: 'P1_32' } },
+  { ids: ['P1_33', 'GPIO111'], gpioNo: 111, modes: [0, 1, 3, 4], custom: { id: 'P1_33', pwm: pwmPins.p1_33 } },
+  { ids: ['P1_34', 'GPIO26'], gpioNo: 26, modes: [0, 1], custom: { id: 'P1_34' } },
+  { ids: ['P1_35', 'GPIO88'], gpioNo: 88, modes: [0, 1], custom: { id: 'P1_35' } },
+  { ids: ['P1_36', 'GPIO110'], gpioNo: 110, modes: [0, 1, 3, 4], custom: { id: 'P1_36', pwm: pwmPins.p1_36 } },
+
+  { ids: ['P2_1', 'GPIO50'], gpioNo: 50, modes: [0, 1, 3, 4], custom: { id: 'P2_01', pwm: pwmPins.p2_1 } },
+  { ids: ['P2_2', 'GPIO59'], gpioNo: 59, modes: [0, 1], custom: { id: 'P2_02' } },
+  { ids: ['P2_3', 'GPIO23'], gpioNo: 23, modes: [0, 1, 3, 4], custom: { id: 'P2_03', pwm: pwmPins.p2_3 } },
+  { ids: ['P2_4', 'GPIO58'], gpioNo: 58, modes: [0, 1], custom: { id: 'P2_04' } },
+  { ids: ['P2_5', 'GPIO30'], gpioNo: 30, modes: [0, 1], custom: { id: 'P2_05' } },
+  { ids: ['P2_6', 'GPIO57'], gpioNo: 57, modes: [0, 1], custom: { id: 'P2_06' } },
+  { ids: ['P2_7', 'GPIO31'], gpioNo: 31, modes: [0, 1], custom: { id: 'P2_07' } },
+  { ids: ['P2_8', 'GPIO60'], gpioNo: 60, modes: [0, 1], custom: { id: 'P2_08' } },
+  { ids: ['P2_9', 'GPIO15'], gpioNo: 15, modes: [0, 1], custom: { id: 'P2_09' } },
+  { ids: ['P2_10', 'GPIO52'], gpioNo: 52, modes: [0, 1], custom: { id: 'P2_10' } },
+  { ids: ['P2_11', 'GPIO14'], gpioNo: 14, modes: [0, 1], custom: { id: 'P2_11' } },
+  /* P2_12: PWR-BTN */
+  /* P2_13: VOUT */
+  /* P2_14: BAT-VIN */
+  /* P2_15: GND */
+  /* P2_16: BAT-TEMP */
+  { ids: ['P2_17', 'GPIO65'], gpioNo: 65, modes: [0, 1], custom: { id: 'P2_17' } },
+  { ids: ['P2_18', 'GPIO47'], gpioNo: 47, modes: [0, 1], custom: { id: 'P2_18' } },
+  { ids: ['P2_19', 'GPIO27'], gpioNo: 27, modes: [0, 1], custom: { id: 'P2_19' } },
+  { ids: ['P2_20', 'GPIO64'], gpioNo: 64, modes: [0, 1], custom: { id: 'P2_20' } },
+  /* P2_21: GND */
+  { ids: ['P2_22', 'GPIO46'], gpioNo: 46, modes: [0, 1], custom: { id: 'P2_22' } },
+  /* P2_23: 3.3V */
+  { ids: ['P2_24', 'GPIO44'], gpioNo: 44, modes: [0, 1], custom: { id: 'P2_24' } },
+  { ids: ['P2_25', 'GPIO41'], gpioNo: 41, modes: [0, 1], custom: { id: 'P2_25' } },
+  /* P2_26: NRST */
+  { ids: ['P2_27', 'GPIO40'], gpioNo: 40, modes: [0, 1], custom: { id: 'P2_27' } },
+  { ids: ['P2_28', 'GPIO116'], gpioNo: 116, modes: [0, 1], custom: { id: 'P2_28' } },
+  { ids: ['P2_29', 'GPIO7'], gpioNo: 7, modes: [0, 1], custom: { id: 'P2_29' } },
+  { ids: ['P2_30', 'GPIO113'], gpioNo: 113, modes: [0, 1], custom: { id: 'P2_30' } },
+  { ids: ['P2_31', 'GPIO19'], gpioNo: 19, modes: [0, 1], custom: { id: 'P2_31' } },
+  { ids: ['P2_32', 'GPIO112'], gpioNo: 112, modes: [0, 1], custom: { id: 'P2_32' } },
+  { ids: ['P2_33', 'GPIO45'], gpioNo: 45, modes: [0, 1], custom: { id: 'P2_33' } },
+  { ids: ['P2_34', 'GPIO115'], gpioNo: 115, modes: [0, 1], custom: { id: 'P2_34' } },
+  { ids: ['P2_35', 'GPIO86'], gpioNo: 86, modes: [0, 1], custom: { id: 'P2_35' } },
+  //{ ids: ['P2_36', 'A7'], analogChannel: 7, modes: [2], custom: { id: 'P2_36' } }, // Doesn't appear to work
+
+  { ids: ['USR0'], ledPath: '/sys/class/leds/beaglebone:green:usr0', modes: [1] },
+  { ids: ['USR1'], ledPath: '/sys/class/leds/beaglebone:green:usr1', modes: [1] },
+  { ids: ['USR2'], ledPath: '/sys/class/leds/beaglebone:green:usr2', modes: [1] },
+  { ids: ['USR3'], ledPath: '/sys/class/leds/beaglebone:green:usr3', modes: [1] }
+];
+


### PR DESCRIPTION
This PR adds support for the [PocketBeagle](https://beagleboard.org/pocket).

If merged, the PR assumes that it will be released with BeagleBone-IO v2.3.0 (see https://github.com/fivdi/beaglebone-io/tree/pocket-beagle#november-2017-pocketbeagle-support).