### PR TITLE
add Node 9 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ node_js:
   - "6"
   - "7"
   - "8"
+  - "9"
 before_script:
   - npm install -g grunt-cli
 env:


### PR DESCRIPTION
BeagleBone-IO supports Node 9 so add Node 9 to travis.