### PR TITLE
Rewrite examples to function on BBB and BBGW

### DIFF
--- a/examples/button.js
+++ b/examples/button.js
@@ -8,7 +8,7 @@ var board = new five.Board({
 });
 
 board.on('ready', function() {
-  var button = new five.Button('GPIO47');
+  var button = new five.Button('P8_8');
 
   button.on('down', function() {
     console.log('down');

--- a/examples/digital-write-performance.js
+++ b/examples/digital-write-performance.js
@@ -8,7 +8,7 @@ var board = new five.Board({
 });
 
 board.on('ready', function() {
-  var pin = board.io.normalize('GPIO46'),
+  var pin = board.io.normalize('P8_7'),
     writesPerSecond,
     time,
     i;

--- a/examples/led-button.js
+++ b/examples/led-button.js
@@ -8,8 +8,8 @@ var board = new five.Board({
 });
 
 board.on('ready', function() {
-  var led = new five.Led('GPIO46');
-  var button = new five.Button('GPIO47');
+  var led = new five.Led('P8_7');
+  var button = new five.Button('P8_8');
 
   button.on('down', function() {
     led.on();

--- a/examples/led.js
+++ b/examples/led.js
@@ -8,7 +8,7 @@ var board = new five.Board({
 });
 
 board.on('ready', function() {
-  var led = new five.Led('GPIO46');
+  var led = new five.Led('P8_7');
   led.blink(500);
 });
 


### PR DESCRIPTION
Some of the example programs use an LED connected to GPIO46 (P8_16) and/or a button connected to GPIO47 (P8_15). By default both of these GPIOs are free for usage on a BBB but they are reserved for wireless communication on a BBGW.

To make these examples function without modification on either a BBB or a BBGW this PR moves the LED to GPIO66 (P8_7) and the button to GPIO67 (P8_8). By default both of these GPIOs are free for usage on a BBB or a BBGW.

Related issue: #48 