### PR TITLE
Fix PWM paths and allow PWM without root privileges on Kernel v4.11+

### DIFF
--- a/lib/pwm-output.js
+++ b/lib/pwm-output.js
@@ -17,15 +17,57 @@ function pwmChipPattern(pinData) {
     '/pwm/pwmchip*';
 }
 
+function waitForAccessPermission(paths) {
+  // This is a bit of a hack but it works and it's not as bad as it initially
+  // looks. When a pwm is exported with kernel v4.11+ udev will set the
+  // permissions on the files used to control pwm to allow these files to be
+  // accessed without root privileges. It takes udev a while to set the
+  // permissions and we need to wait for it to complete its work to avoid
+  // EACCES errors. To determine when udev has finished its work we
+  // continuously try to access the appropriate files until they are
+  // successfully accessed. We stop after 10000 tries. Under normal conditions
+  // approximately 200 tries are needed to successfully access the first path
+  // in the paths array. The remaining paths can typically be accessed
+  // successfully on the first try. On kernels prior to v4.11 the code will
+  // actually attempt to access the file 10000 times if Node.js was started
+  // without root privileges. The 10000 attemps take approximately 2 seconds
+  // to complete and in the end an EACCES is thrown.
+
+  paths.forEach(function (path) {
+    var tries = 0,
+      fd;
+
+    while (true) {
+      try {
+        tries += 1;
+        fd = fs.openSync(path, 'r+');
+        fs.closeSync(fd);
+        break;
+      } catch (e) {
+        if (tries === 10000) {
+          throw e;
+        }
+      }
+    }
+  });
+}
+
 function PwmOutput(pinData, period) {
   var matches,
     pwmChipPath,
+    pwmChannelPattern,
     pwmChannelPath,
     channel;
 
   if (!(this instanceof PwmOutput)) {
     return new PwmOutput(pinData);
   }
+
+  // The paths for PWM files vary from kernel to kernel.
+  // On kernel v4.4 and v4.9 they will look something like this:
+  // /sys/devices/platform/ocp/48302000.epwmss/48302200.pwm/pwm/pwmchip*/pwm0/duty_cycle
+  // On kernel v4.11+ they will look something like this:
+  // /sys/devices/platform/ocp/48302000.epwmss/48302200.pwm/pwm/pwmchip*/pwm-*:0/duty_cycle
 
   matches = glob.sync(pwmChipPattern(pinData));
   if (matches.length !== 1) {
@@ -36,13 +78,30 @@ function PwmOutput(pinData, period) {
 
   pwmChipPath = matches[0];
   channel = pinData.custom.pwm.channel;
-  pwmChannelPath = pwmChipPath + '/pwm' + channel;
+  pwmChannelPattern = pwmChipPath + '/pwm*' + channel;
 
-  matches = glob.sync(pwmChannelPath);
-  if (matches.length !== 1) {
+  matches = glob.sync(pwmChannelPattern);
+  if (matches.length === 0) {
     // The pwm channel hasn't been exported yet, so export it.
     fs.writeFileSync(pwmChipPath + '/export', channel, FS_OPTIONS);
+    matches = glob.sync(pwmChannelPattern);
   }
+
+  if (matches.length !== 1) {
+    throw new Error(
+      'Can\'t find unique directory macthing "' + pwmChannelPattern + '"'
+    );
+  }
+
+  pwmChannelPath = matches[0];
+
+  // On kernel v4.11+ we wait for udev to set the permissions on the files
+  // used to control pwm enabling to be accessed without root privileges.
+  waitForAccessPermission([
+    pwmChannelPath + '/period',
+    pwmChannelPath + '/enable',
+    pwmChannelPath + '/duty_cycle'
+  ]);
 
   this.period = period;
   fs.writeFileSync(pwmChannelPath + '/period', period, FS_OPTIONS);


### PR DESCRIPTION
This PR fixes PWM paths on kernel v4.11+ (#45) and allows access to PWM without root privileges on kernel v4.11+ (#46.)

